### PR TITLE
Correct SCM URL from Gitlab to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The goal of this project is not to create yet-another-compliance-regime, but ins
 First, clone this repo to your desktop.
 
 ```bash
-git clone https://gitlab.com/sckg/sckg
+git clone https://github.com/sckg/sckg
 cd sckg
 ```
 


### PR DESCRIPTION
There might be a private repo on Gitlab, but hard to tell and unlikely to be accessible to public community members from quick tests on Gitlab, unauthenticated or authenticated.